### PR TITLE
扩大阅读器滚动的命中区域

### DIFF
--- a/lib/features/reader/images.dart
+++ b/lib/features/reader/images.dart
@@ -1425,7 +1425,9 @@ class ContinuousModeState extends State<_ContinuousMode>
           position: photoViewController.position + offset,
         );
       },
-      onPointerSignal: onPointerSignal,
+      // Mouse wheel is handled by the outer full-viewport Listener so that
+      // scrolling still works when the cursor is outside the image bounds
+      // (e.g. side margins after limitImageWidth).
       child: widget,
     );
 
@@ -1491,15 +1493,22 @@ class ContinuousModeState extends State<_ContinuousMode>
       width = height * 0.7;
     }
 
-    return PhotoView.customChild(
-      backgroundDecoration: BoxDecoration(color: context.colorScheme.surface),
-      childSize: Size(width, height),
-      minScale: 1.0,
-      maxScale: 2.5,
-      strictScale: true,
-      controller: photoViewController,
-      onScaleUpdate: onScaleUpdate,
-      child: SizedBox(width: width, height: height, child: widget),
+    // Outer Listener covers the full reader viewport so mouse-wheel events
+    // work even when the cursor is over empty margins (PhotoView centers a
+    // narrower child when limitImageWidth is enabled).
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerSignal: onPointerSignal,
+      child: PhotoView.customChild(
+        backgroundDecoration: BoxDecoration(color: context.colorScheme.surface),
+        childSize: Size(width, height),
+        minScale: 1.0,
+        maxScale: 2.5,
+        strictScale: true,
+        controller: photoViewController,
+        onScaleUpdate: onScaleUpdate,
+        child: SizedBox(width: width, height: height, child: widget),
+      ),
     );
   }
 


### PR DESCRIPTION
避免从上到下的阅读模式下仅图片区域可滚动